### PR TITLE
fix: use the vite BASE_URL when creating the web history

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -9,7 +9,7 @@ import 'uno.css'
 
 const app = createApp(App)
 const router = createRouter({
-  history: createWebHistory(),
+  history: createWebHistory(import.meta.env.BASE_URL),
   routes,
 })
 app.use(router)


### PR DESCRIPTION
This allows vite-plugin-pages to correctly route to defined pages when overriding the base in vite.

Fixes #10 