### PR TITLE
chore: type error

### DIFF
--- a/vite.config.ts
+++ b/vite.config.ts
@@ -7,6 +7,8 @@ import Pages from 'vite-plugin-pages'
 import Components from 'unplugin-vue-components/vite'
 import AutoImport from 'unplugin-auto-import/vite'
 import UnoCSS from 'unocss/vite'
+
+// @ts-expect-error failed to resolve types
 import VueMacros from 'unplugin-vue-macros/vite'
 
 export default defineConfig({


### PR DESCRIPTION
### Description

The addition ignores the ts type detection error caused by macros